### PR TITLE
Adding baremetal fulfillment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ In a separate terminal, test the request:
 ```bash
 curl -X GET http://localhost:8081/api/v1/nodes/list
 curl -X GET http://localhost:8081/api/v1/networks/list
-curl -X POST http://localhost:8081/api/v1/baremetal-order/fulfill -d '{"network_id": "<some network>",
-  "Nodes": [{"resource_class": "fc830", "number": 3},
-         {"resource_class": "<some gpu class>", "number":2}]}'
+curl -X POST http://localhost:8081/api/v1/baremetal-order/fulfill \
+  -H "Content-Type: application/json" \
+  -d '{"network_id": "provisioning",
+       "nodes": [{"resource_class": "fc830", "number": 3},
+                 {"resource_class": "gpu", "number": 2}]
+  }'
 ```
-
 ## How to run the application as a Podman container
 
 ### Install the prerequiste packages for buildah and podman

--- a/app.py
+++ b/app.py
@@ -1,13 +1,18 @@
+import asyncio
+from datetime import datetime, timezone, timedelta
 from esi_api.connections import get_openstack_connection, get_esi_connection
 from esi.lib import nodes
-from flask import Flask, jsonify
-from threading import Event
+from flask import Flask, jsonify, request
+import logging
+from threading import Event, Thread
 import json
 import signal
 import os
 import sys
 import traceback
 
+LOG = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 app = Flask(__name__)
 
@@ -66,13 +71,109 @@ def nodes_list():
     except Exception as e:
         return jsonify({"error": str(e)})
 
+def run_fulfillment_background(network_id, requested_nodes):
+    conn = get_esi_connection(cloud=cloud_name)
+    # Run async fulfillment tasks inside this thread
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.run_until_complete(fulfill_order_loop(conn, network_id, requested_nodes))
+    loop.close()
+
+async def fulfill_order_loop(conn, network_id, requested_nodes):
+    # Keep in the loop until all nodes requests fulfilled
+    while True:
+        tasks = []
+        now = datetime.now(timezone.utc)
+        offers_all = list(conn.lease.offers(available_start_time=now,
+                                            available_end_time=now + timedelta(days=7)))
+        for item in requested_nodes:
+            resource_class = item['resource_class']
+            number = item['number']
+            if number <= 0:
+                continue
+            # Filter the offer with resource_class
+            offers_filtered = [o for o in offers_all
+                               if o.resource_class == resource_class]
+            # Grab the first X offers to claim
+            offers_to_claim = offers_filtered[:number]
+
+            for offer in offers_to_claim:
+                tasks.append(fulfill_offer_task(conn, offer, network_id))
+                item['number'] -= 1
+
+        if not tasks:
+            LOG.info('No offer is available yet. Retrying...')
+            await asyncio.sleep(60)
+            continue
+        await asyncio.gather(*tasks)
+        # Break the loop if all node requests fulfilled
+        if all(item['number'] <= 0 for item in requested_nodes):
+            break
+        # Retry if not all requests fulfilled yet
+        LOG.info('Not all requests fulfilled yet. Retrying...')
+        await asyncio.sleep(60)
+
+async def fulfill_offer_task(conn, offer, network_id):
+    """
+    Claims an offer, waits for lease to become active,
+    and attaches the network to the leased node.
+    """
+    try:
+        lease = conn.lease.claim_offer(offer.id)
+        LOG.info(f"Claimed offer {offer.id}: lease {lease.get('uuid')}")
+        while True:
+            lease_status = conn.lease.get_lease(lease.get('uuid')).status
+            LOG.info('Get lease status...')
+            if lease_status == 'active':
+                LOG.info(f'Lease {lease.get("uuid")} is active')
+                break
+            await asyncio.sleep(30)
+        nodes.network_attach(conn, lease.get('resource_uuid'), {'network': network_id})
+        LOG.info(f"Network {network_id} attached to node {lease.get('resource_uuid')}")
+    except Exception as e:
+        LOG.error(f"Error fulfilling offer {offer.id}: {e}")
+        raise RuntimeError(f'Error fulfilling offer {offer.id}: {e}')
+
 @app.route('/api/v1/baremetal-order/fulfill', methods=['POST'])
 def baremetal_order_fulfill():
-    response = {
-        'status': 'CREATED'
-        , 'code': 201
+    """
+    Fulfills a baremetal node order.
+    A bare-metal order should be like this:
+    {
+        "network_id": "<network UUID or name>",
+        "nodes": [
+            {"resource_class": "fc430", "number": 2},
+            {"resource_class": "gpu", "number": 1}
+        ]
     }
-    return jsonify(response)
+    """
+    try:
+        order_data = request.get_json()
+        if not order_data:
+            return jsonify({'error': 'Missing order data'}), 400
+
+        network_id = order_data.get('network_id')
+        requested_nodes = order_data.get('nodes')
+        if not network_id or not requested_nodes:
+            return jsonify({'error': 'Missing network_id or nodes'}), 400
+
+        # Verify if the network exists
+        conn = get_openstack_connection(cloud=cloud_name)
+        network_res = conn.network.find_network(network_id)
+        if not network_res:
+            return jsonify({'error': f'Network "{network_id}" not found'}), 404
+
+        # Start fulfillment in background
+        t = Thread(target=run_fulfillment_background, args=(network_id, requested_nodes))
+        t.start()
+
+        return jsonify({
+            'status': 'CREATED',
+            'code': 201,
+        })
+
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
 
 @app.route('/api/v1/networks/list', methods=['GET'])
 def networks_list():


### PR DESCRIPTION
When receiving the baremetal-order/fulfill request, the application:
1. creates a new thread to fulfill the order and returns `201 CREATED` immediately.
2. in the fulfillment thread, it runs asyncio event loop to start each `fulfill_offer_task()` concurrently
3. the `fulfill_offer_task()` claims an offer, waits for the lease to be active and then attaches the network to the node