### PR TITLE
Adding Kafka/zookeeper to order fulfill API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ curl -X GET http://localhost:8081/api/v1/nodes/list
 curl -X GET http://localhost:8081/api/v1/networks/list
 curl -X POST http://localhost:8081/api/v1/baremetal-order/fulfill \
   -H "Content-Type: application/json" \
-  -d '{"network_id": "provisioning",
-       "nodes": [{"resource_class": "fc830", "number": 3},
-                 {"resource_class": "gpu", "number": 2}]
+  -d '{"order_id": "123_xyz",
+       "network_id": "provisioning",
+       "nodes": [{"resource_class": "fc430", "number": 1}]
   }'
 ```
 ## How to run the application as a Podman container

--- a/consumer.py
+++ b/consumer.py
@@ -1,0 +1,81 @@
+from kafka import KafkaConsumer
+import threading
+import traceback
+import logging
+import sys
+import signal
+
+class FlaskKafka():
+    def __init__(self, interrupt_event, **kw):
+        self.consumer = KafkaConsumer(**kw)
+        self.handlers={}
+        self.interrupt_event = interrupt_event
+        logger = logging.getLogger('flask-kafka-consumer')
+        ch = logging.StreamHandler(sys.stdout)
+        ch.setLevel(logging.INFO)
+        formatter = logging.Formatter('[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s')
+        ch.setFormatter(formatter)
+        logger.addHandler(ch)
+        logger.setLevel(logging.INFO)
+        self.logger = logger
+
+
+    def _add_handler(self, topic, handler):
+        if self.handlers.get(topic) is None:
+            self.handlers[topic] = []
+        self.handlers[topic].append(handler)
+
+    def handle(self, topic):
+        def decorator(f):
+            self._add_handler(topic, f)
+            return f
+        return decorator
+
+    def _run_handlers(self, msg):
+        try:
+            handlers = self.handlers[msg.topic]
+            for handler in handlers:
+                handler(msg)
+            self.consumer.commit()
+        except Exception as e:
+            if("CommitFailedError:" in str(e)):
+                self.logger.warn(str(e))
+            else:
+                self.logger.critical(str(e), exc_info=1)
+                self.consumer.close()
+                signal.raise_signal(signal.SIGTERM)
+
+    def signal_term_handler(self, signal, frame):
+        self.logger.info("closing consumer")
+        self.consumer.close()
+        sys.exit(0)
+
+
+    def _start(self):
+        self.consumer.subscribe(topics=tuple(self.handlers.keys()))
+        self.logger.info("starting consumer...registered signterm")
+
+        for msg in self.consumer:
+            self.logger.debug("TOPIC: {}, PAYLOAD: {}".format(msg.topic, msg.value))
+            self._run_handlers(msg)
+            # stop the consumer
+            if self.interrupt_event.is_set():
+                self.interrupted_process()
+                self.interrupt_event.clear()
+
+
+    def interrupted_process(self, *args):
+        self.logger.info("closing consumer")
+        self.consumer.close()
+        sys.exit(0)
+
+
+    def _run(self):
+        self.logger.info(" * The flask Kafka application is consuming")
+        t = threading.Thread(target=self._start)
+        t.start()
+
+
+    # run the consumer application
+    def run(self):
+        self._run()


### PR DESCRIPTION
- When a baremetal order is received, or completed (or error), send the message to topic `esi-fulfill-order-loop`. 
- Also create statuses on Zookeeper for order running and complete.
- When an ESI offer is claimed, send the message to topic `esi-fulfill-offer-task`
