### PR TITLE
Adding floating ip option to baremetal order fulfillment

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ curl -X POST http://localhost:8081/api/v1/baremetal-order/fulfill \
   -H "Content-Type: application/json" \
   -d '{"order_id": "123_xyz",
        "network_id": "provisioning",
-       "nodes": [{"resource_class": "fc430", "number": 2}]
+       "nodes": [{"resource_class": "fc430", "number": 2}],
+       "create_floating_ip": "True"
   }'
 # Or provision the nodes with metalsmith
 curl -X POST http://localhost:8081/api/v1/baremetal-order/fulfill \
@@ -49,6 +50,7 @@ curl -X POST http://localhost:8081/api/v1/baremetal-order/fulfill \
   -d '{"order_id": "123_xyz",
        "network_id": "network-uitest",
        "nodes": [{"resource_class": "fc430", "number": 1}],
+       "create_floating_ip": "True",
        "image": "centos-image",
        "ssh_keys": [<ssh_key_string1>, <ssh_key_string2>...]
   }'


### PR DESCRIPTION
1. add `creating_floating_ip` option in request data
2. if `creating_floating_ip` is true, create an external network floating ip and assign this ip to the first node claimed.
3. apply to both network attachment and image provisioning options.